### PR TITLE
Chore: Enforce code quality via Ruff/Black formatting pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3.9
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.292
+    hooks:
+      - id: ruff
+        args: [ --fix ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,17 @@ Your pull request will now be available for review by the project maintainers. T
 
 <br>
 
+# Pre-commit Hooks 🪝
+
+This project uses `pre-commit` to enforce code quality with `black` and `ruff`. Before committing, please install the pre-commit hooks:
+
+1. Install pre-commit: `pip install pre-commit`
+2. Install the hooks: `pre-commit install`
+
+Now, every time you commit, `black` will format your code and `ruff` will check for linting errors automatically!
+
+<br>
+
 # Note: 🔨
 
 > - Do not edit/delete someone else's code in this repository. You can only insert new files/folder in this repository.


### PR DESCRIPTION
Closes #1071.

This PR adds a .pre-commit-config.yaml to enforce Ruff and Black formatting on all future commits. I have also added instructions to CONTRIBUTING.md on how to install and use the hooks.